### PR TITLE
Add type parameter to API url to fetch movies only

### DIFF
--- a/movie-app/src/utilities/utils.js
+++ b/movie-app/src/utilities/utils.js
@@ -9,11 +9,11 @@ const makeJSON = async url => {
 }
 
 export const getMoviesByName = (movie_title, page) => {
-    const base_url = `http://www.omdbapi.com/?s=${movie_title}&apikey=${API_KEY}&page=${page}`;
+    const base_url = `http://www.omdbapi.com/?s=${movie_title}&apikey=${API_KEY}&page=${page}&type=movie`;
     return makeJSON(base_url);
 }
 export const getMovieById = movieID => {
-    const apiURL = `http://www.omdbapi.com/?i=${movieID}&apikey=${API_KEY}`;
+    const apiURL = `http://www.omdbapi.com/?i=${movieID}&apikey=${API_KEY}&type=movie`;
     return makeJSON(apiURL);
 }
 


### PR DESCRIPTION
## Changes
1. Add `type=movie` to the URLs data is fetched from.

## Purpose
Filter games and TV series out of search results.

## Approach
Add parameter to URL in utils.js and API filters results.

Closes #59 